### PR TITLE
Revise Fortran include directories

### DIFF
--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -102,14 +102,12 @@ pymt_components = [
 def build_interoperability():
     compiler = new_fcompiler()
     compiler.customize()
-    compiler.add_include_dir(os.path.join(sys.prefix, 'lib'))
-    compiler.add_include_dir(os.path.join(sys.prefix, 'include'))
 
     cmd = []
     cmd.append(compiler.compiler_f90[0])
     cmd.append(compiler.compile_switch)
     cmd.append('-fPIC')
-    for include_dir in compiler.include_dirs:
+    for include_dir in common_flags['include_dirs']:
         cmd.append('-I{}'.format(include_dir))
     cmd.append('bmi_interoperability.f90')
 

--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -108,6 +108,8 @@ def build_interoperability():
     cmd.append(compiler.compile_switch)
     cmd.append('-fPIC')
     for include_dir in common_flags['include_dirs']:
+        if os.path.isabs(include_dir) is False:
+            include_dir = os.path.join(sys.prefix, "include", include_dir)
         cmd.append('-I{}'.format(include_dir))
     cmd.append('bmi_interoperability.f90')
 


### PR DESCRIPTION
This PR makes changes to how include directories are set for Fortran builds. I had been using the *add_include_dir* method of the numpy Fortran compiler, but this was redundant -- the `common_flags` dict already defines standard include directories. Further, if additional include directories are listed (in the plugin.yaml file), they'll be included in the include path.