### PR TITLE
Match Python types, not Fortran

### DIFF
--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -24,6 +24,8 @@ DTYPE_F_TO_PY = {
 for k in list(DTYPE_F_TO_PY.keys()):
     DTYPE_F_TO_PY[k.upper()] = DTYPE_F_TO_PY[k]
 
+ENOMSG = 42  # No message of desired type
+
 cdef extern from "bmi_interoperability.h":
     int MAX_COMPONENT_NAME
     int MAX_VAR_NAME
@@ -391,7 +393,7 @@ cdef class {{ pymt_class }}:
                                                  buffer.data,
                                                  grid_size))
         else:
-            ok_or_raise(5)
+            ok_or_raise(ENOMSG)
 
         return buffer
 
@@ -412,7 +414,7 @@ cdef class {{ pymt_class }}:
         elif type == DTYPE_FLOAT:
             return np.asarray(<np.float32_t[:grid_size]>ptr)
         else:
-            return ok_or_raise(6)
+            return ok_or_raise(ENOMSG)
 
     cpdef set_value(self, var_name, np.ndarray buffer):
         cdef int grid_id = self.get_var_grid(var_name)
@@ -438,6 +440,6 @@ cdef class {{ pymt_class }}:
                                                  buffer.data,
                                                  grid_size))
         else:
-            ok_or_raise(7)
+            ok_or_raise(ENOMSG)
 
         return buffer

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -372,13 +372,13 @@ cdef class {{ pymt_class }}:
         cdef int grid_size = self.get_grid_size(grid_id)
         type = self.get_var_type(var_name)
 
-        if type.startswith('double'):
+        if type == DTYPE_DOUBLE:
             ok_or_raise(<int>bmi_get_value_double(self._bmi,
                                                   to_bytes(var_name),
                                                   len(var_name),
                                                   buffer.data,
                                                   grid_size))
-        elif type.startswith('int'):
+        elif type == DTYPE_INT:
             ok_or_raise(<int>bmi_get_value_int(self._bmi,
                                                to_bytes(var_name),
                                                len(var_name),
@@ -403,9 +403,9 @@ cdef class {{ pymt_class }}:
                                            to_bytes(var_name),
                                            len(var_name), &ptr))
 
-        if type.startswith('double'):
+        if type == DTYPE_DOUBLE:
             return np.asarray(<np.float64_t[:grid_size]>ptr)
-        elif type.startswith('int'):
+        elif type == DTYPE_INT:
             return np.asarray(<np.int32_t[:grid_size]>ptr)
         else:
             return np.asarray(<np.float32_t[:grid_size]>ptr)
@@ -415,13 +415,13 @@ cdef class {{ pymt_class }}:
         cdef int grid_size = self.get_grid_size(grid_id)
         type = self.get_var_type(var_name)
 
-        if type.startswith('double'):
+        if type == DTYPE_DOUBLE:
             ok_or_raise(<int>bmi_set_value_double(self._bmi,
                                                   to_bytes(var_name),
                                                   len(var_name),
                                                   buffer.data,
                                                   grid_size))
-        elif type.startswith('int'):
+        elif type == DTYPE_INT:
             ok_or_raise(<int>bmi_set_value_int(self._bmi,
                                                to_bytes(var_name),
                                                len(var_name),

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -384,12 +384,14 @@ cdef class {{ pymt_class }}:
                                                len(var_name),
                                                buffer.data,
                                                grid_size))
-        else:
+        elif type == DTYPE_FLOAT:
             ok_or_raise(<int>bmi_get_value_float(self._bmi,
                                                  to_bytes(var_name),
                                                  len(var_name),
                                                  buffer.data,
                                                  grid_size))
+        else:
+            ok_or_raise(5)
 
         return buffer
 
@@ -407,8 +409,10 @@ cdef class {{ pymt_class }}:
             return np.asarray(<np.float64_t[:grid_size]>ptr)
         elif type == DTYPE_INT:
             return np.asarray(<np.int32_t[:grid_size]>ptr)
-        else:
+        elif type == DTYPE_FLOAT:
             return np.asarray(<np.float32_t[:grid_size]>ptr)
+        else:
+            return ok_or_raise(6)
 
     cpdef set_value(self, var_name, np.ndarray buffer):
         cdef int grid_id = self.get_var_grid(var_name)
@@ -427,10 +431,13 @@ cdef class {{ pymt_class }}:
                                                len(var_name),
                                                buffer.data,
                                                grid_size))
-        else:
+        elif type == DTYPE_FLOAT:
             ok_or_raise(<int>bmi_set_value_float(self._bmi,
                                                  to_bytes(var_name),
                                                  len(var_name),
                                                  buffer.data,
                                                  grid_size))
+        else:
+            ok_or_raise(7)
+
         return buffer

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -10,12 +10,16 @@ SIZEOF_FLOAT = 8 * ctypes.sizeof(ctypes.c_float)
 SIZEOF_DOUBLE = 8 * ctypes.sizeof(ctypes.c_double)
 SIZEOF_INT = 8 * ctypes.sizeof(ctypes.c_int)
 
+DTYPE_FLOAT = 'float{bits}'.format(bits=SIZEOF_FLOAT)
+DTYPE_DOUBLE = 'float{bits}'.format(bits=SIZEOF_DOUBLE)
+DTYPE_INT = 'float{bits}'.format(bits=SIZEOF_INT)
+
 DTYPE_F_TO_PY = {
-    'real': 'float{bits}'.format(bits=SIZEOF_FLOAT),
-    'real*4': 'float{bits}'.format(bits=SIZEOF_FLOAT),
-    'double precision': 'float{bits}'.format(bits=SIZEOF_DOUBLE),
-    'real*8': 'float{bits}'.format(bits=SIZEOF_DOUBLE),
-    'integer': 'int{bits}'.format(bits=SIZEOF_INT),
+    'real': DTYPE_FLOAT,
+    'real*4': DTYPE_FLOAT,
+    'double precision': DTYPE_DOUBLE,
+    'real*8': DTYPE_DOUBLE,
+    'integer': DTYPE_INT,
 }
 for k in list(DTYPE_F_TO_PY.keys()):
     DTYPE_F_TO_PY[k.upper()] = DTYPE_F_TO_PY[k]


### PR DESCRIPTION
This PR fixes a set of mistakes. In the *get_value*, *get_value_ptr*, and *set_value* methods, I had been matching against Fortran types (e.g., "double precision") in order to call the correct BMI method for the type. Instead, I should have been using numpy dtype strings, which are returned from the *get_var_type* method in this Cython wrapper.

I also made improvements to the logic in these methods; e.g., now raising an exception if none of the supported types are matched.