### PR TITLE
Update Fortran template for BMI v2.0

### DIFF
--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -72,6 +72,8 @@ cdef extern from "bmi_interoperability.h":
                              int n_chars, int *itemsize)
     int bmi_get_var_nbytes(int model, const char *var_name,
                            int n_chars, int *nbytes)
+    int bmi_get_var_location(int model, const char *var_name, int n_chars,
+                         char *location, int m_chars)
 
     int bmi_get_value_int(int model, const char *var_name, int n_chars,
                           void *buffer, int size)
@@ -347,6 +349,15 @@ cdef class {{ pymt_class }}:
                                             to_bytes(var_name),
                                             len(var_name), &nbytes))
         return nbytes
+
+    cpdef object get_var_location(self, var_name):
+        self.reset_str_buffer()
+        ok_or_raise(<int>bmi_get_var_location(self._bmi,
+                                              to_bytes(var_name),
+                                              len(var_name),
+                                              self.STR_BUFFER,
+                                              MAX_TYPE_NAME))
+        return to_string(self.STR_BUFFER)
 
     cpdef np.ndarray get_value(self, var_name, np.ndarray buffer):
         cdef int grid_id = self.get_var_grid(var_name)

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -63,6 +63,9 @@ cdef extern from "bmi_interoperability.h":
     int bmi_get_grid_x(int model, int grid_id, double *x, int size)
     int bmi_get_grid_y(int model, int grid_id, double *y, int size)
     int bmi_get_grid_z(int model, int grid_id, double *z, int size)
+    int bmi_get_grid_node_count(int model, int grid_id, int *count)
+    int bmi_get_grid_edge_count(int model, int grid_id, int *count)
+    int bmi_get_grid_face_count(int model, int grid_id, int *count)
 
     int bmi_get_var_type(int model, const char *var_name, int n_chars,
                          char *type, int m_chars)
@@ -317,6 +320,24 @@ cdef class {{ pymt_class }}:
         ok_or_raise(<int>bmi_get_grid_z(self._bmi, grid_id,
                                         &grid_z[0], size))
         return grid_z
+
+    cpdef int get_grid_node_count(self, grid_id):
+        cdef int node_count
+        ok_or_raise(<int>bmi_get_grid_node_count(self._bmi, grid_id,
+                                                 &node_count))
+        return node_count
+
+    cpdef int get_grid_edge_count(self, grid_id):
+        cdef int edge_count
+        ok_or_raise(<int>bmi_get_grid_edge_count(self._bmi, grid_id,
+                                                 &edge_count))
+        return edge_count
+
+    cpdef int get_grid_face_count(self, grid_id):
+        cdef int face_count
+        ok_or_raise(<int>bmi_get_grid_face_count(self._bmi, grid_id,
+                                                 &face_count))
+        return face_count
 
     cpdef object get_var_type(self, var_name):
         self.reset_str_buffer()

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -66,6 +66,14 @@ cdef extern from "bmi_interoperability.h":
     int bmi_get_grid_node_count(int model, int grid_id, int *count)
     int bmi_get_grid_edge_count(int model, int grid_id, int *count)
     int bmi_get_grid_face_count(int model, int grid_id, int *count)
+    int bmi_get_grid_edge_nodes(int model, int grid_id,
+                                int *edge_nodes, int size)
+    int bmi_get_grid_face_edges(int model, int grid_id,
+                                int *face_edges, int size)
+    int bmi_get_grid_face_nodes(int model, int grid_id,
+                                int *face_nodes, int size)
+    int bmi_get_grid_nodes_per_face(int model, int grid_id,
+                                    int *nodes_per_face, int size)
 
     int bmi_get_var_type(int model, const char *var_name, int n_chars,
                          char *type, int m_chars)
@@ -338,6 +346,38 @@ cdef class {{ pymt_class }}:
         ok_or_raise(<int>bmi_get_grid_face_count(self._bmi, grid_id,
                                                  &face_count))
         return face_count
+
+    cpdef np.ndarray get_grid_edge_nodes(self, grid_id, \
+                                         np.ndarray[int, ndim=1] edge_nodes):
+        cdef int size = len(edge_nodes)
+        if size > 0:
+            ok_or_raise(<int>bmi_get_grid_edge_nodes(self._bmi, grid_id,
+                                                     &edge_nodes[0], size))
+        return edge_nodes
+
+    cpdef np.ndarray get_grid_face_edges(self, grid_id, \
+                                         np.ndarray[int, ndim=1] face_edges):
+        cdef int size = len(face_edges)
+        if size > 0:
+            ok_or_raise(<int>bmi_get_grid_face_edges(self._bmi, grid_id,
+                                                     &face_edges[0], size))
+        return face_edges
+
+    cpdef np.ndarray get_grid_face_nodes(self, grid_id, \
+                                         np.ndarray[int, ndim=1] face_nodes):
+        cdef int size = len(face_nodes)
+        if size > 0:
+            ok_or_raise(<int>bmi_get_grid_face_nodes(self._bmi, grid_id,
+                                                     &face_nodes[0], size))
+        return face_nodes
+
+    cpdef np.ndarray get_grid_nodes_per_face(self, grid_id, \
+                                         np.ndarray[int, ndim=1] nodes_per_face):
+        cdef int size = self.get_grid_face_count(grid_id)
+        if size > 0:
+            ok_or_raise(<int>bmi_get_grid_nodes_per_face(self._bmi, grid_id,
+                                                         &nodes_per_face[0], size))
+        return nodes_per_face
 
     cpdef object get_var_type(self, var_name):
         self.reset_str_buffer()

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -37,7 +37,6 @@ cdef extern from "bmi_interoperability.h":
     int bmi_initialize(int model, const char *config_file, int n_chars)
     int bmi_update(int model)
     int bmi_update_until(int model, double until)
-    int bmi_update_frac(int model, double frac)
     int bmi_finalize(int model)
 
     int bmi_get_component_name(int model, char *name, int n_chars)
@@ -64,8 +63,6 @@ cdef extern from "bmi_interoperability.h":
     int bmi_get_grid_x(int model, int grid_id, double *x, int size)
     int bmi_get_grid_y(int model, int grid_id, double *y, int size)
     int bmi_get_grid_z(int model, int grid_id, double *z, int size)
-    int bmi_get_grid_connectivity(int model, int grid_id, int *conn, int size)
-    int bmi_get_grid_offset(int model, int grid_id, int *offset, int size)
 
     int bmi_get_var_type(int model, const char *var_name, int n_chars,
                          char *type, int m_chars)
@@ -249,10 +246,6 @@ cdef class {{ pymt_class }}:
         status = <int>bmi_update(self._bmi)
         ok_or_raise(status)
 
-    cpdef update_frac(self, time_frac):
-        status = <int>bmi_update_frac(self._bmi, time_frac)
-        ok_or_raise(status)
-
     cpdef update_until(self, time_later):
         status = <int>bmi_update_until(self._bmi, time_later)
         ok_or_raise(status)
@@ -322,20 +315,6 @@ cdef class {{ pymt_class }}:
         ok_or_raise(<int>bmi_get_grid_z(self._bmi, grid_id,
                                         &grid_z[0], size))
         return grid_z
-
-    cpdef np.ndarray get_grid_connectivity(self, grid_id, \
-                                           np.ndarray[int, ndim=1] conn):
-        cdef int size = self.get_grid_size(grid_id)
-        ok_or_raise(<int>bmi_get_grid_connectivity(self._bmi, grid_id,
-                                                   &conn[0], size))
-        return conn
-
-    cpdef np.ndarray get_grid_offset(self, grid_id, 
-                                     np.ndarray[int, ndim=1] offset):
-        cdef int size = self.get_grid_size(grid_id)
-        ok_or_raise(<int>bmi_get_grid_offset(self._bmi, grid_id,
-                                             &offset[0], size))
-        return offset
 
     cpdef object get_var_type(self, var_name):
         self.reset_str_buffer()

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -8,7 +8,7 @@ module bmi_interoperability
 {%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') %}
 
   use, intrinsic :: iso_c_binding
-  use bmif
+  use bmif_2_0
 
 {%- if cookiecutter.libraries %}
 {%- for lib in cookiecutter.libraries.split(',') %}

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -452,6 +452,62 @@ contains
   end function bmi_get_grid_face_count
 
   !
+  ! Get the edge-node connectivity of a grid.
+  !
+  function bmi_get_grid_edge_nodes(model_index, grid_id, edge_nodes, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: edge_nodes(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_edge_nodes(grid_id, edge_nodes)
+  end function bmi_get_grid_edge_nodes
+
+  !
+  ! Get the face-edge connectivity of a grid.
+  !
+  function bmi_get_grid_face_edges(model_index, grid_id, face_edges, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: face_edges(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_face_edges(grid_id, face_edges)
+  end function bmi_get_grid_face_edges
+
+  !
+  ! Get the face-node connectivity of a grid.
+  !
+  function bmi_get_grid_face_nodes(model_index, grid_id, face_nodes, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: face_nodes(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_face_nodes(grid_id, face_nodes)
+  end function bmi_get_grid_face_nodes
+
+  !
+  ! Get the number of nodes per face in a grid.
+  !
+  function bmi_get_grid_nodes_per_face(model_index, grid_id, nodes_per_face, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: nodes_per_face(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_nodes_per_face(grid_id, nodes_per_face)
+  end function bmi_get_grid_nodes_per_face
+
+  !
   ! Get the type for the specified variable.
   !
   function bmi_get_var_type(model_index, var_name, n, var_type, m) &

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -513,6 +513,36 @@ contains
   end function bmi_get_var_nbytes
 
   !
+  ! Get the location where the specified variable is defined.
+  !
+  function bmi_get_var_location(model_index, var_name, n, var_location, m) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    character (len=1, kind=c_char), intent(out) :: var_location(m)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+    character (len=m, kind=c_char) :: var_location_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+    do i = 1, m
+       var_location_(i:i) = var_location(i)
+    enddo
+
+    status = model_array(model_index)%get_var_location(var_name_, var_location_)
+
+    do i = 1, len(trim(var_location_))
+        var_location(i) = var_location_(i:i)
+    enddo
+    var_location = var_location//C_NULL_CHAR
+  end function bmi_get_var_location
+
+  !
   ! Get a copy of an integer variable's values, flattened.
   !
   function bmi_get_value_int(model_index, var_name, n, buffer, m) &

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -8,7 +8,6 @@ module bmi_interoperability
 {%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') %}
 
   use, intrinsic :: iso_c_binding
-  use bmif
 
 {%- if cookiecutter.libraries %}
 {%- for lib in cookiecutter.libraries.split(',') %}

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -246,17 +246,6 @@ contains
   end function bmi_update
 
   !
-  ! Advance the model by a fraction of a time step.
-  !
-  function bmi_update_frac(model_index, time_frac) bind(c) result(status)
-    integer (c_int), intent(in), value :: model_index
-    real (c_double), intent(in), value :: time_frac
-    integer (c_int) :: status
-
-    status = model_array(model_index)%update_frac(time_frac)
-  end function bmi_update_frac
-
-  !
   ! Advance the model to a time in the future.
   !
   function bmi_update_until(model_index, time_later) bind(c) result(status)
@@ -421,34 +410,6 @@ contains
 
     status = model_array(model_index)%get_grid_z(grid_id, grid_z)
   end function bmi_get_grid_z
-
-  !
-  ! Get the connectivity of a grid's nodes.
-  !
-  function bmi_get_grid_connectivity(model_index, grid_id, grid_conn, n) &
-       bind(c) result(status)
-    integer (c_int), intent(in), value :: model_index
-    integer (c_int), intent(in), value :: grid_id
-    integer (c_int), intent(in), value :: n
-    integer (c_int), intent(out) :: grid_conn(n)
-    integer (c_int) :: status
-
-    status = model_array(model_index)%get_grid_connectivity(grid_id, grid_conn)
-  end function bmi_get_grid_connectivity
-
-  !
-  ! Get the offset of a grid's nodes.
-  !
-  function bmi_get_grid_offset(model_index, grid_id, grid_offset, n) &
-       bind(c) result(status)
-    integer (c_int), intent(in), value :: model_index
-    integer (c_int), intent(in), value :: grid_id
-    integer (c_int), intent(in), value :: n
-    integer (c_int), intent(out) :: grid_offset(n)
-    integer (c_int) :: status
-
-    status = model_array(model_index)%get_grid_offset(grid_id, grid_offset)
-  end function bmi_get_grid_offset
 
   !
   ! Get the type for the specified variable.

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -8,6 +8,7 @@ module bmi_interoperability
 {%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') %}
 
   use, intrinsic :: iso_c_binding
+  use bmif
 
 {%- if cookiecutter.libraries %}
 {%- for lib in cookiecutter.libraries.split(',') %}

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -413,6 +413,45 @@ contains
   end function bmi_get_grid_z
 
   !
+  ! Get the number of nodes in a grid.
+  !
+  function bmi_get_grid_node_count(model_index, grid_id, node_count) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(out) :: node_count
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_node_count(grid_id, node_count)
+  end function bmi_get_grid_node_count
+
+  !
+  ! Get the number of edges in a grid.
+  !
+  function bmi_get_grid_edge_count(model_index, grid_id, edge_count) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(out) :: edge_count
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_edge_count(grid_id, edge_count)
+  end function bmi_get_grid_edge_count
+
+  !
+  ! Get the number of faces in a grid.
+  !
+  function bmi_get_grid_face_count(model_index, grid_id, face_count) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(out) :: face_count
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_face_count(grid_id, face_count)
+  end function bmi_get_grid_face_count
+
+  !
   ! Get the type for the specified variable.
   !
   function bmi_get_var_type(model_index, var_name, n, var_type, m) &

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -41,6 +41,10 @@ int bmi_get_grid_x(int model, int grid_id, double *x, int size);
 int bmi_get_grid_y(int model, int grid_id, double *y, int size);
 int bmi_get_grid_z(int model, int grid_id, double *z, int size);
 
+int bmi_get_grid_node_count(int model, int grid_id, int *count);
+int bmi_get_grid_edge_count(int model, int grid_id, int *count);
+int bmi_get_grid_face_count(int model, int grid_id, int *count);
+
 int bmi_get_var_type(int model, const char *var_name, int n_chars,
 		     char *type, int m_chars);
 int bmi_get_var_units(int model, const char *var_name, int n_chars,

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -13,7 +13,6 @@ int bmi_new(void);
 int bmi_initialize(int model, const char *config_file, int n_chars);
 int bmi_update(int model);
 int bmi_update_until(int model, double until);
-int bmi_update_frac(int model, double frac);
 int bmi_finalize(int model);
 
 int bmi_get_component_name(int model, char *name, int n_chars);
@@ -41,8 +40,6 @@ int bmi_get_grid_origin(int model, int grid_id, double *origin, int rank);
 int bmi_get_grid_x(int model, int grid_id, double *x, int size);
 int bmi_get_grid_y(int model, int grid_id, double *y, int size);
 int bmi_get_grid_z(int model, int grid_id, double *z, int size);
-int bmi_get_grid_connectivity(int model, int grid_id, int *conn, int size);
-int bmi_get_grid_offset(int model, int grid_id, int *offset, int size);
 
 int bmi_get_var_type(int model, const char *var_name, int n_chars,
 		     char *type, int m_chars);

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -49,6 +49,8 @@ int bmi_get_var_itemsize(int model, const char *var_name, int n_chars,
 			 int *itemsize);
 int bmi_get_var_nbytes(int model, const char *var_name, int n_chars,
 		       int *nbytes);
+int bmi_get_var_location(int model, const char *var_name, int n_chars,
+		     char *location, int m_chars);
 
 int bmi_get_value_int(int model, const char *var_name, int n_chars,
 		      void *buffer, int size);

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -44,6 +44,11 @@ int bmi_get_grid_z(int model, int grid_id, double *z, int size);
 int bmi_get_grid_node_count(int model, int grid_id, int *count);
 int bmi_get_grid_edge_count(int model, int grid_id, int *count);
 int bmi_get_grid_face_count(int model, int grid_id, int *count);
+int bmi_get_grid_edge_nodes(int model, int grid_id, int *edge_nodes, int size);
+int bmi_get_grid_face_edges(int model, int grid_id, int *face_edges, int size);
+int bmi_get_grid_face_nodes(int model, int grid_id, int *face_nodes, int size);
+int bmi_get_grid_nodes_per_face(int model, int grid_id,
+				int *nodes_per_face, int size);
 
 int bmi_get_var_type(int model, const char *var_name, int n_chars,
 		     char *type, int m_chars);

--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -69,6 +69,11 @@ libraries = [
 {%- endif %}
 ]
 
+# Locate directories under Windows %LIBRARY_PREFIX%.
+if sys.platform.startswith("win"):
+    common_flags["include_dirs"].append(os.path.join(sys.prefix, "Library", "include"))
+    common_flags["library_dirs"].append(os.path.join(sys.prefix, "Library", "lib"))
+
 ext_modules = [
 {%- for entry_point in cookiecutter.entry_points.split(',') %}
     {%- set pymt_class = entry_point.split('=')[0] -%}
@@ -106,7 +111,8 @@ def build_interoperability():
     cmd = []
     cmd.append(compiler.compiler_f90[0])
     cmd.append(compiler.compile_switch)
-    cmd.append('-fPIC')
+    if sys.platform.startswith("win") is False:
+        cmd.append("-fPIC")
     for include_dir in common_flags['include_dirs']:
         if os.path.isabs(include_dir) is False:
             include_dir = os.path.join(sys.prefix, "include", include_dir)


### PR DESCRIPTION
This PR updates the Fortran template in the cookiecutter to use BMI v2.0.

The C, C++, and Python templates still need to be updated.